### PR TITLE
Pass credentials on `fetch` call

### DIFF
--- a/src/script.js
+++ b/src/script.js
@@ -29,7 +29,7 @@ const prevent = e => e.preventDefault()
 
 // Soft nav
 function browseTo (href) {
-  fetch(href).then(r => r.text().then(t => {
+  fetch(href, { credentials: 'include' }).then(r => r.text().then(t => {
     const parsed = new DOMParser().parseFromString(t, 'text/html')
     const table = parsed.querySelectorAll('table')[0].innerHTML
     document.body.querySelectorAll('table')[0].innerHTML = table


### PR DESCRIPTION
By default 'fetch' call does not pass cookies or basic auth credentials to the backend,
that results in a HTTP 401 if gossa is behind basic auth.

This PR fixes the issue.

See:  https://github.com/qutebrowser/qutebrowser/issues/1792#issuecomment-448024889