### PR TITLE
Add environment variables to run gossa as unprivileged user

### DIFF
--- a/docker/build.Dockerfile
+++ b/docker/build.Dockerfile
@@ -3,6 +3,9 @@ COPY . /gossaSrc
 RUN cd /gossaSrc && make
 
 FROM alpine
+ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared"
 EXPOSE 8001
+RUN apk add --no-cache su-exec
 COPY --from=builder /gossaSrc/gossa /gossa
-ENTRYPOINT [ "/gossa", "-h", "0.0.0.0", "/shared" ]
+RUN echo -e 'exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} ${DATADIR}'>> /start.sh
+ENTRYPOINT [ "sh", "/start.sh" ]

--- a/docker/download.Dockerfile
+++ b/docker/download.Dockerfile
@@ -4,7 +4,7 @@ ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS=
 EXPOSE 8001
 
 RUN apk add --no-cache su-exec
-RUN wget https://github.com/pldubouilh/gossa/releases/download/v0.0.7/gossa-linux64 && mv gossa-linux64 /gossa && chmod +x /gossa
+RUN wget https://github.com/pldubouilh/gossa/releases/download/v0.0.8/gossa-linux64 && mv gossa-linux64 /gossa && chmod +x /gossa
 
 RUN echo -e 'exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} ${DATADIR}'>> /start.sh
 ENTRYPOINT [ "sh", "/start.sh" ]

--- a/docker/download.Dockerfile
+++ b/docker/download.Dockerfile
@@ -1,5 +1,10 @@
 FROM alpine
-EXPOSE 8001
-RUN wget https://github.com/pldubouilh/gossa/releases/download/v0.0.7/gossa-linux64 && mv gossa-linux64 /gossa && chmod +x /gossa
-ENTRYPOINT [ "/gossa", "-h", "0.0.0.0", "/shared" ]
 
+ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared"
+EXPOSE 8001
+
+RUN apk add --no-cache su-exec
+RUN wget https://github.com/pldubouilh/gossa/releases/download/v0.0.7/gossa-linux64 && mv gossa-linux64 /gossa && chmod +x /gossa
+
+RUN echo -e 'exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} ${DATADIR}'>> /start.sh
+ENTRYPOINT [ "sh", "/start.sh" ]


### PR DESCRIPTION
Solves #31 

This adds the following env variables:
- UID, GID: the uid and gid which gossa will run as
- HOST, PORT: sets the -h and -p flags (defaults to 0.0.0.0 and 8001)
- PREFIX: sets the --prefix flag (defaults to /)
- FOLLOW_SYMLINKS: sets the --symlinks flag (defaults to false)
- SKIP_HIDDEN_FILES: sets the -k flag (defaults to true)
- DATADIR: the directory within the container which will be shared by gossa