### PR TITLE
Dockerfile updates

### DIFF
--- a/support/build.Dockerfile
+++ b/support/build.Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:latest as builder
+FROM golang:1.18 as builder
 COPY . /gossaSrc
 RUN cd /gossaSrc && make
 
-FROM alpine
+FROM alpine:3.15
 ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared" READONLY="false" VERB="false"
 EXPOSE 8001
 RUN apk add --no-cache su-exec

--- a/support/build.Dockerfile
+++ b/support/build.Dockerfile
@@ -4,8 +4,7 @@ RUN cd /gossaSrc && make
 
 FROM alpine:3.15
 ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared" READONLY="false" VERB="false"
-EXPOSE 8001
 RUN apk add --no-cache su-exec
+COPY ./support/entrypoint.sh /entrypoint.sh
 COPY --from=builder /gossaSrc/gossa /gossa
-RUN echo -e 'exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} -ro=${READONLY} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} --verb=${VERB} ${DATADIR}'>> /start.sh
-ENTRYPOINT [ "sh", "/start.sh" ]
+ENTRYPOINT "/entrypoint.sh"

--- a/support/build.Dockerfile
+++ b/support/build.Dockerfile
@@ -3,9 +3,9 @@ COPY . /gossaSrc
 RUN cd /gossaSrc && make
 
 FROM alpine
-ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared" READONLY="false"
+ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared" READONLY="false" VERB="false"
 EXPOSE 8001
 RUN apk add --no-cache su-exec
 COPY --from=builder /gossaSrc/gossa /gossa
-RUN echo -e 'exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} -ro=${READONLY} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} ${DATADIR}'>> /start.sh
+RUN echo -e 'exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} -ro=${READONLY} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} --verb=${VERB} ${DATADIR}'>> /start.sh
 ENTRYPOINT [ "sh", "/start.sh" ]

--- a/support/entrypoint.sh
+++ b/support/entrypoint.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} -ro=${READONLY} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} --verb=${VERB} ${DATADIR}


### PR DESCRIPTION
Made a few changes to the Dockerfile

- Added VERB environment variable to pass --verb
- Pin the versions of golang and alpine - this way future golang updates won't break the build
- Removed the EXPOSE command, with the port being configurable this doesn't seem useful
- Separated the entrypoint script to a separate file

These changes are built and available on dockerhub at `fowlmouth/gossa:2022-03-27`