### PR TITLE
feat: harden security, bump alpine version, add healthcheck

### DIFF
--- a/support/build.Dockerfile
+++ b/support/build.Dockerfile
@@ -1,10 +1,13 @@
 FROM golang:1.18 as builder
+WORKDIR /gossaSrc
 COPY . /gossaSrc
-RUN cd /gossaSrc && make
+RUN make
 
-FROM alpine:3.15
+FROM docker.io/library/alpine:3.20
 ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared" READONLY="false" VERB="false"
 RUN apk add --no-cache su-exec
 COPY ./support/entrypoint.sh /entrypoint.sh
 COPY --from=builder /gossaSrc/gossa /gossa
+USER nobody
 ENTRYPOINT "/entrypoint.sh"
+HEALTHCHECK --timeout=5s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8001 || exit 1

--- a/support/build.Dockerfile
+++ b/support/build.Dockerfile
@@ -5,9 +5,10 @@ RUN make
 
 FROM docker.io/library/alpine:3.20
 ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared" READONLY="false" VERB="false"
-RUN apk add --no-cache su-exec
-COPY ./support/entrypoint.sh /entrypoint.sh
+RUN addgroup -g ${GID} user \
+    && adduser -D -u ${UID} -G user user
 COPY --from=builder /gossaSrc/gossa /gossa
-USER nobody
-ENTRYPOINT "/entrypoint.sh"
+USER ${UID}:${GID}
+WORKDIR /home/user/${DATADIR}
+ENTRYPOINT /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} -ro=${READONLY} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} --verb=${VERB} ${DATADIR}
 HEALTHCHECK --timeout=5s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8001 || exit 1

--- a/support/build.Dockerfile
+++ b/support/build.Dockerfile
@@ -5,10 +5,11 @@ RUN make
 
 FROM docker.io/library/alpine:3.20
 ENV UID="1000" GID="1000" HOST="0.0.0.0" PORT="8001" PREFIX="/" FOLLOW_SYMLINKS="false" SKIP_HIDDEN_FILES="true" DATADIR="/shared" READONLY="false" VERB="false"
+COPY --from=builder /gossaSrc/gossa /gossa
 RUN addgroup -g ${GID} user \
     && adduser -D -u ${UID} -G user user
-COPY --from=builder /gossaSrc/gossa /gossa
+WORKDIR ${DATADIR}
+RUN chown ${UID}:${GID} ${DATADIR}
 USER ${UID}:${GID}
-WORKDIR /home/user/${DATADIR}
 ENTRYPOINT /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} -ro=${READONLY} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} --verb=${VERB} ${DATADIR}
 HEALTHCHECK --timeout=5s --start-period=5s --retries=3 CMD wget --no-verbose --tries=1 --spider 127.0.0.1:8001 || exit 1

--- a/support/docker-compose.yml
+++ b/support/docker-compose.yml
@@ -2,9 +2,28 @@ version: '2'
 
 services:
   gossa-server:
-    image: pldubouilh/gossa
+    image: docker.io/pldubouilh/gossa:latest
     container_name: gossa
     restart: always
+    read_only: true
+    # uncomment to set the user
+    # user: "1000:1000"
+    # environment:
+      #- READONLY=true # uncomment to set gossa as read only
+      #- UID=1000 # this should match the user set above
+      #- GID=1000 # this should match the user's group
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETGID
+      - SETUID
+    # uncomment to set resource usage limits
+    # deploy:
+    #   resources:
+    #     limits:
+    #       cpus: "2"
+    #       memory: 250m
+    #       pids: 1024
     ports:
       - 8001:8001
     volumes:

--- a/support/docker-compose.yml
+++ b/support/docker-compose.yml
@@ -8,10 +8,11 @@ services:
     read_only: true
     # uncomment to set the user
     # user: "1000:1000"
+    # userns_mode: "keep-id" # uncomment if using rootless podman as well as the x-podman directive at the bottom
     # environment:
       #- READONLY=true # uncomment to set gossa as read only
-      #- UID=1000 # this should match the user set above
-      #- GID=1000 # this should match the user's group
+      # - UID=1000 # this should match the user set above
+      # - GID=1000 # this should match the user's group
     cap_drop:
       - ALL
     cap_add:
@@ -33,3 +34,6 @@ services:
 #      - "traefik.port=8001"
 #      - "traefik.backend=gossa"
 #      - "traefik.frontend.rule=Host:${GOSSA}.${DOMAIN}"
+
+# x-podman: # uncomment if using rootless podman as well as the userns_mode directive at the top
+#  in_pod: false

--- a/support/entrypoint.sh
+++ b/support/entrypoint.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec su-exec ${UID}:${GID} /gossa -h ${HOST} -p ${PORT} -k=${SKIP_HIDDEN_FILES} -ro=${READONLY} --symlinks=${FOLLOW_SYMLINKS} --prefix=${PREFIX} --verb=${VERB} ${DATADIR}


### PR DESCRIPTION
This PR hardens the security of the container by:

- changing the default user in the container to a non root one (customizable with the UID and GID env vars)
- dropping all capabilities and adding only the ones that are required
- setting the filesystem as read only
- bumps the alpine version since 3.15 is end of life already
- removes the redundant `su-exec` and `entrypoint.sh`

It also adds a default healthcheck command.

For more info see https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-3-limit-capabilities-grant-only-specific-capabilities-needed-by-a-container
