### PR TITLE
Update caddy config examples to caddy v2.8+

### DIFF
--- a/support/readme.md
+++ b/support/readme.md
@@ -80,7 +80,7 @@ Caddy v2 Caddyfile
 myserver.com
 
 # gate access
-basicauth {
+basic_auth {
   root $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG # password is "hiccup"
   ro_user1 $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG # password is "hiccup"
   ro_user2 $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG # password is "hiccup"
@@ -152,7 +152,7 @@ Caddy v2 Caddyfile
 ```sh
 myserver.com
 
-basicauth {
+basic_auth {
   user1 $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG # password is "hiccup"
   user2 $2a$14$Zkx19XLiW6VYouLHR5NmfOFU0z2GTNmpkT/5qqR7hx4IjWJPDhjvG # password is "hiccup"
 }


### PR DESCRIPTION
With [Caddy 2.8](https://github.com/caddyserver/caddy/releases/tag/v2.8.0) the `basicauth` Caddyfile directive has been renamed to `basic_auth`. The old name continues to work but logs a deprecation warning.

This PR reflects that change in the caddy v2 config examples in `support/readme.md`.