### PR TITLE
Replace deprecated "apple-mobile-web-app-capable" tag

### DIFF
--- a/ui/ui.tmpl
+++ b/ui/ui.tmpl
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="theme-color" content="rgb(45,52,54)">
     <meta name="msapplication-navbutton-color" content="rgb(45,52,54)">
-    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="mobile-web-app-capable" content="yes">
     <meta name="viewport" content="width=device-width">
 
     <link rel="manifest" href='data:application/manifest+json,{"name":"{{.Title}}","short_name":"{{.Title}}","description":"  ","icons":[{"src":"data:image/svg+xml;base64,favicon_will_be_here","sizes":"150x150","type":"image/svg+xml"}],"background":"rgb(45,52,54)","theme_color":"rgb(45,52,54)","display":"standalone"}' />


### PR DESCRIPTION
Chrome warns that the "apple-mobile-web-app-capable" tag is deprecated and should be replaced with "mobile-web-app-capable". Cursory research suggests that Apple [removed the original tag](https://forums.developer.apple.com/forums/thread/36820) (among others) back[ in iOS8](https://stackoverflow.com/questions/24889100/ios-8-removed-minimal-ui-viewport-property-are-there-other-soft-fullscreen), however Apple themselves don't appear to have publicly facing documentation stating such.

Other projects have also made this change:
https://github.com/openstreetmap/iD/issues/10425
https://github.com/vercel/next.js/pull/70363