### PR TITLE
Work around Firefox's transient activation requirement for opening file picker

### DIFF
--- a/ui/script.js
+++ b/ui/script.js
@@ -749,40 +749,52 @@ document.body.addEventListener('keydown', e => {
     return
   }
 
-  // Ctrl keys
-  if ((e.ctrlKey || e.metaKey) && !e.shiftKey) {
-    switch (e.code) {
-      case 'KeyC':
-        return prevent(e) || isRo() || cpPath()
+  // Modifier keys
+  if (!e.shiftKey) {
+    if (e.ctrlKey || e.metaKey) {
+      switch (e.code) {
+        case 'KeyC':
+          return prevent(e) || isRo() || cpPath()
 
-      case 'KeyH':
-        return prevent(e) || isRo() || helpToggle()
+        case 'KeyH':
+          return prevent(e) || isRo() || helpToggle()
 
-      case 'KeyX':
-        return prevent(e) || isRo() || onCut()
+        case 'KeyX':
+          return prevent(e) || isRo() || onCut()
 
-      case 'KeyR':
-        return prevent(e) || refresh()
+        case 'KeyR':
+          return prevent(e) || refresh()
 
-      case 'KeyV':
-        return prevent(e) || isRo() || ensureMove() || onPaste()
+        case 'KeyV':
+          return prevent(e) || isRo() || ensureMove() || onPaste()
 
-      case 'Backspace':
-        return prevent(e) || isRo() || window.rm(e)
+        case 'Backspace':
+          return prevent(e) || isRo() || window.rm(e)
 
-      case 'KeyE':
-        return prevent(e) || isRo() || window.rename(e)
+        case 'KeyE':
+          return prevent(e) || isRo() || window.rename(e)
 
-      case 'KeyM':
-        return prevent(e) || isRo() || window.mkdirBtn()
+        case 'KeyM':
+          return prevent(e) || isRo() || window.mkdirBtn()
 
-      case 'KeyU':
-        return prevent(e) || isRo() || manualUpload.click()
+        case 'KeyU':
+          return prevent(e) || isRo() || manualUpload.click()
 
-      case 'Enter':
-      case 'ArrowRight':
-        return prevent(e) || dl(getASelected())
+        case 'Enter':
+        case 'ArrowRight':
+          return prevent(e) || dl(getASelected())
+      }
     }
+  } else {
+      // Workaround Firefox requirement for transient activation
+      // https://developer.mozilla.org/en-US/docs/Web/Security/User_activation
+      // Firefox requires user interaction (that is not reserved by the user agent)
+      // before a file picker can be displayed. This means that ctrl/meta are not
+      // usable as modifiers until the user clicks the page or presses another
+      // non-modifier key. To work around this, the shift key can be used, instead.
+      if (e.code == 'KeyU') {
+          return prevent(e) || isRo() || manualUpload.click()
+      }
   }
 
   switch (e.code) {

--- a/ui/ui.tmpl
+++ b/ui/ui.tmpl
@@ -26,7 +26,7 @@
         <tr><td>Ctrl/Meta + C</td><td>copy URL to clipboard</td></tr>
         <tr><td>Ctrl/Meta + E</td><td>rename item</td></tr>
         <tr><td>Ctrl/Meta + Backspace</td><td>delete item</td></tr>
-        <tr><td>Ctrl/Meta + U</td><td>upload new file/folder</td></tr>
+        <tr><td>Ctrl/Meta/Shift + U</td><td>upload new file/folder</td></tr>
         <tr><td>Ctrl/Meta + M</td><td>create a new directory</td></tr>
         <tr><td>Ctrl/Meta + X</td><td>cut selected path</td></tr>
         <tr><td>Ctrl/Meta + V</td><td>paste previously selected paths to directory</td></tr>


### PR DESCRIPTION
Firefox requires transient activation (user interaction) prior to opening the file picker.

This is documented by Mozilla [here](https://developer.mozilla.org/en-US/docs/Web/Security/User_activation).

This documentation states that mouse clicks and keypresses count as transient activation, but unfortunately, keypresses preceded by modifiers reserved by the user agent (such as ctrl/meta) do not count as transient activation. Because of this, the user currently must first click on the page or press a key (thus activating fuzzy search) before the ctrl+u keybind will work to upload a file in Firefox.

This PR works around this by allowing shift+u as an alternative keybind. I understand that this is not the most ideal solution, but I cannot find any better options that work around this Firefox requirement. Please let me know if you have any suggestions!