### PR TITLE
Replace if-else chain in rpc function with switch statement

### DIFF
--- a/gossa.go
+++ b/gossa.go
@@ -231,11 +231,12 @@ func rpc(w http.ResponseWriter, r *http.Request) {
 	check(err)
 	json.Unmarshal(bodyBytes, &rpc)
 
-	if rpc.Call == "mkdirp" {
+	switch rpc.Call {
+	case "mkdirp":
 		err = os.MkdirAll(enforcePath(rpc.Args[0]), os.ModePerm)
-	} else if rpc.Call == "mv" {
+	case "mv":
 		err = os.Rename(enforcePath(rpc.Args[0]), enforcePath(rpc.Args[1]))
-	} else if rpc.Call == "rm" {
+	case "rm":
 		err = os.RemoveAll(enforcePath(rpc.Args[0]))
 	}
 


### PR DESCRIPTION
This if-else chain only exists to check the value of rpc.Call, thus it is a little cleaner (and technically, though very negligibly more efficient) to match rpc.Call to its possible values using a switch statement.

With the number of possible cases right now, this is a very minor change. This is simply something I noticed while working on a separate feature (sha1/sha256/sha512/md5 checksuming) that makes use of rpc. 

The aforementioned checksuming feature is not quite yet ready, but when it is, is it something that would be of interest to this project? I'm developing it regardless as I need it for my personal Gossa instances, but if it doesn't extend too far beyond the scope of this project, I'd like to contribute it once I clean it up a bit from my current implementation.