### PR TITLE
Checksums feature

### DIFF
--- a/ui/style.css
+++ b/ui/style.css
@@ -344,12 +344,8 @@ h1 > span:hover {
   right: 30px;
 }
 
-#helpHead {
-  margin-top: 60px;
-  text-align: center;
-}
-
-#helpTable {
+#helpTable,
+#sumsTable {
   border-collapse: collapse;
   width: 70%;
   max-width: 790px;
@@ -360,7 +356,8 @@ h1 > span:hover {
   overflow-y: auto;
 }
 
-#helpTable td {
+#helpTable td,
+#sumsTable td {
   width: 200px;
   padding: 9px;
   border: 1px solid #fff;
@@ -369,7 +366,8 @@ h1 > span:hover {
   margin: 0;
 }
 
-#help {
+#help,
+#sums {
   background-color: black;
   position: absolute;
   top: 0px;

--- a/ui/ui.tmpl
+++ b/ui/ui.tmpl
@@ -30,12 +30,21 @@
         <tr><td>Ctrl/Meta + M</td><td>create a new directory</td></tr>
         <tr><td>Ctrl/Meta + X</td><td>cut selected path</td></tr>
         <tr><td>Ctrl/Meta + V</td><td>paste previously selected paths to directory</td></tr>
+        <tr><td>Ctrl/Meta + Z</td><td>copy checksums of selected file</td></tr>
         <tr><td>Ctrl + click</td><td>download selected item as archive</td></tr>
         <tr><td>click file icon </td><td>rename item</td></tr>
         <tr><td>double click file icon</td><td>delete item</td></tr>
         <tr><td>drag-and-drop item on UI</td><td>move item</td></tr>
         <tr><td>drag-and-drop external item</td><td>upload file/folders</td></tr>
         <tr><td>any other letter</td><td>fuzzy search</td></tr>
+    </tbody></table></div>
+
+    <div onclick="window.sumsOff()" style="display: none;" id="sums"><table id="sumsTable"><tbody>
+        <tr><td>Key</td><td>Hash Algorithm</td></tr>
+        <tr><td>1</td><td>copy sha1 sum</td></tr>
+        <tr><td>2</td><td>copy sha256 sum</td></tr>
+        <tr><td>3</td><td>copy sha512 sum</td></tr>
+        <tr><td>5</td><td>copy md5 sum</td></tr>
     </tbody></table></div>
 
     <div style="display: none;" onclick="window.quitAll()" id="quitAll"><i style="display: none;" id="toast">cant reach server</i></div>


### PR DESCRIPTION
Here is the checksums feature I was talking about. I implemented it the way we discussed, with a separate menu (ctrl+z) for copying the hashes directly to the clipboard.

Some things that I want to mention:
- Unlike the help menu, I decided to not close the sums menu when any key is pressed, as this may lead the user to believe their keystroke did something, as the menu closes when a hash is copied successfully.
- I based the UI heavily around the help menu. It fits in well, but I basically made a slightly modified duplicate of the help menu functions in the frontend.
- The way I used the RPC callback to indicate that something should be copied to the clipboard is a little weird. Let me know if you want me to change it. Currently, I have the frontend RPC function writing the return value from the backend RPC to the clipboard if `cb` is simply the boolean "true".  I could make a proper callback function if that would be preferred over my simple approach, but I think I would have to pass the RPC output to the callback for all uses of RPC? I'm not super familiar with JS, so there may be a better approach.
- I removed something from the style sheet that seemed unused. Let me know if I was wrong or if you want to keep it. I just noticed that when applying those styles to the sums menu, I couldn't find where one of them was actually used.

For lack of a better place to chat, I also wanted to let you know that I will try out blockfast when I get a chance! I've been very busy lately with a new job.