### PR TITLE
Enable upload of multiple files on mobile devices

### DIFF
--- a/ui/ui.tmpl
+++ b/ui/ui.tmpl
@@ -50,7 +50,7 @@
     <div style="display: none;" onclick="window.quitAll()" id="quitAll"><i style="display: none;" id="toast">cant reach server</i></div>
     <textarea style="display: none;" id="text-editor"></textarea>
     <div id="drop-grid"></div>
-    <input type="file" id="clickupload" style="display:none"/>
+    <input type="file" id="clickupload" multiple style="display:none"/>
 
     <h1 onclick="return titleClick(event)">.{{.Title}}</h1>
 


### PR DESCRIPTION
Hi!

First, thanks a lot for this great tool. It was exactly what I was looking for. I wanted to have an easy way of sending files to a shared directory on my laptop and gossa is perfect for that.

I noticed that on the mobile view (Firefox on Android) I can only ever select a single file for uploading. However, just specifying `multiple="1"` on the `<input type="file" ...>` element fixed the issue and I can upload multiple files directly. The Javascript code seems to handle this fine (most likely it’s very similar to drag and drop).

Would you be interested in merging this change? :)

Best regards,
Stefan